### PR TITLE
update shellerror on newer nushell versions

### DIFF
--- a/src/from_parquet.rs
+++ b/src/from_parquet.rs
@@ -29,12 +29,12 @@ fn convert_to_nu(field: &Field, span: Span) -> Value {
             .try_into()
             .map(|l| Value::int(l, span))
             .unwrap_or_else(|e| Value::Error {
-                error: ShellError::CantConvert(
-                    "i64".into(),
-                    "u64".into(),
+                error: ShellError::CantConvert {
+                    to_type: "i64".into(),
+                    from_type: "u64".into(),
                     span,
-                    Some(e.to_string()),
-                ),
+                    help: Some(e.to_string()),
+                },
             }),
         Field::Float(f) => Value::float((*f).into(), span),
         Field::Double(f) => Value::float(*f, span),


### PR DESCRIPTION
Hi.
Currently, if you try to `cargo install --path .` you will get a build error. This fixes it. 