### PR TITLE
feat: add -m/--metadata flag to show metadata instead of data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,9 +593,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.1"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
@@ -969,6 +969,7 @@ version = "0.0.2"
 dependencies = [
  "bytes",
  "chrono",
+ "indexmap",
  "nu-plugin",
  "nu-protocol",
  "parquet",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ nu-protocol = { path = "../nushell/crates/nu-protocol", version="0.77.2"}
 bytes = "1.4.0"
 chrono = { version = "0.4.23", features = ["serde"] }
 parquet = "36.0.0"
+indexmap = "1.9.3"
 
 # Would be nice if this worked but it does not
 # [patch.crates-io]

--- a/README.md
+++ b/README.md
@@ -45,3 +45,20 @@ open -r sample.parquet | from parquet | first 10
 │ # │ registration… │ id │ first_name │ last_name │    email     │ gender │  ip_address  │      cc      │   country    │ birthdate  │  salary   │    title     │ comments │
 ╰───┴───────────────┴────┴────────────┴───────────┴──────────────┴────────┴──────────────┴──────────────┴──────────────┴────────────┴───────────┴──────────────┴──────────╯
 ```
+
+### Displaying Metadata
+
+Display metadata, instead of data, from the parquet file by passing the `--metadata, -m` flag to `from parquet`:
+
+```bash
+open -r sample.parquet | from parquet --metadata
+╭────────────┬───────────────────────────────────────────────────────────────────────────╮
+│ version    │ 1                                                                         │
+│ creator    │ parquet-mr version 1.8.1 (build 4aba4dae7bb0d4edbcf7923ae1339f28fd3f7fcf) │
+│ num_rows   │ 1000                                                                      │
+│ key_values │ [list 0 items]                                                            │
+│ schema     │ {record 3 fields}                                                         │
+│ row_groups │ [table 1 row]                                                             │
+╰────────────┴───────────────────────────────────────────────────────────────────────────╯
+```
+

--- a/src/from_parquet.rs
+++ b/src/from_parquet.rs
@@ -1,9 +1,13 @@
 use bytes::Bytes;
 use chrono::{DateTime, Duration, FixedOffset, TimeZone};
-use nu_protocol::{ShellError, Span, Value};
+use indexmap::map::IndexMap;
+use nu_protocol::{ShellError, Span, Spanned, Value};
+use parquet::basic::{ConvertedType, LogicalType, TimeUnit, Type as PhysicalType};
+use parquet::file::metadata::{KeyValue, RowGroupMetaData};
 use parquet::file::reader::FileReader;
 use parquet::file::serialized_reader::SerializedFileReader;
 use parquet::record::{Field, Row};
+use parquet::schema::types::{SchemaDescriptor, Type};
 use std::convert::TryInto;
 use std::ops::Add;
 
@@ -85,6 +89,233 @@ pub fn from_parquet_bytes(bytes: Vec<u8>, span: Span) -> Value {
     for record in iter {
         let row = convert_parquet_row(record, span);
         vals.push(row);
+    }
+    Value::List { vals, span }
+}
+
+pub fn metadata_from_parquet_bytes(bytes: Vec<u8>, span: Span) -> Value {
+    let cursor = Bytes::from(bytes);
+    let reader = SerializedFileReader::new(cursor).unwrap();
+    let metadata = reader.metadata();
+
+    let mut val = IndexMap::new();
+
+    let file_metadata = metadata.file_metadata();
+    val.insert(
+        "version".to_string(),
+        Value::int(file_metadata.version() as i64, span),
+    );
+    val.insert(
+        "creator".to_string(),
+        Value::string(file_metadata.created_by().unwrap_or(""), span),
+    );
+    val.insert(
+        "num_rows".to_string(),
+        Value::int(file_metadata.num_rows() as i64, span),
+    );
+    val.insert(
+        "key_values".to_string(),
+        key_value_metadata_to_value(file_metadata.key_value_metadata(), span),
+    );
+    val.insert(
+        "schema".to_string(),
+        schema_descriptor_to_value(file_metadata.schema_descr(), span),
+    );
+    val.insert(
+        "row_groups".to_string(),
+        row_groups_to_value(metadata.row_groups(), span),
+    );
+
+    Value::from(Spanned { item: val, span })
+}
+
+fn key_value_metadata_to_value(key_value_metadata: Option<&Vec<KeyValue>>, span: Span) -> Value {
+    let mut vals = Vec::new();
+    if let Some(key_value_metadata) = key_value_metadata {
+        for key_value in key_value_metadata {
+            let mut val = IndexMap::new();
+            val.insert(
+                "key".to_string(),
+                Value::string(key_value.key.clone(), span),
+            );
+            val.insert(
+                "value".to_string(),
+                Value::string(key_value.value.clone().unwrap_or("".to_string()), span),
+            );
+            vals.push(Value::from(Spanned { item: val, span }));
+        }
+    }
+    Value::List { vals, span }
+}
+
+fn schema_descriptor_to_value(schema: &SchemaDescriptor, span: Span) -> Value {
+    let mut val = IndexMap::new();
+    val.insert("name".to_string(), Value::string(schema.name(), span));
+    val.insert(
+        "num_columns".to_string(),
+        Value::int(schema.num_columns() as i64, span),
+    );
+    val.insert(
+        "schema".to_string(),
+        schema_to_value(schema.root_schema(), span),
+    );
+    Value::from(Spanned { item: val, span })
+}
+
+fn schema_to_value(tp: &Type, span: Span) -> Value {
+    match *tp {
+        Type::PrimitiveType {
+            ref basic_info,
+            physical_type,
+            type_length,
+            scale,
+            precision,
+        } => {
+            let mut val = IndexMap::new();
+            val.insert(
+                "name".to_string(),
+                Value::string(basic_info.name().clone(), span),
+            );
+            val.insert(
+                "repetition".to_string(),
+                Value::string(basic_info.repetition().to_string(), span),
+            );
+            val.insert(
+                "type".to_string(),
+                Value::string(physical_type.to_string(), span),
+            );
+            val.insert(
+                "type_length".to_string(),
+                match physical_type {
+                    PhysicalType::BYTE_ARRAY | PhysicalType::FIXED_LEN_BYTE_ARRAY => {
+                        Value::int(type_length as i64, span)
+                    }
+                    _ => Value::nothing(span),
+                },
+            );
+            val.insert(
+                "logical_type".to_string(),
+                Value::string(
+                    logical_or_converted_type_to_string(
+                        basic_info.logical_type(),
+                        basic_info.converted_type(),
+                        precision,
+                        scale,
+                    ),
+                    span,
+                ),
+            );
+            Value::from(Spanned { item: val, span })
+        }
+        Type::GroupType {
+            basic_info: _,
+            ref fields,
+        } => {
+            let mut vals = Vec::new();
+            for field in fields {
+                vals.push(schema_to_value(field, span));
+            }
+            Value::List { vals, span }
+        }
+    }
+}
+
+fn logical_or_converted_type_to_string(
+    logical_type: Option<LogicalType>,
+    converted_type: ConvertedType,
+    precision: i32,
+    scale: i32,
+) -> String {
+    match logical_type {
+        Some(logical_type) => match logical_type {
+            LogicalType::Bson => "BSON".to_string(),
+            LogicalType::Date => "DATE".to_string(),
+            LogicalType::Decimal { precision, scale } => {
+                format!("DECIMAL({},{})", precision, scale)
+            }
+            LogicalType::Enum => "ENUM".to_string(),
+            LogicalType::Integer {
+                bit_width,
+                is_signed,
+            } => {
+                format!("INTEGER({},{})", bit_width, is_signed)
+            }
+            LogicalType::Json => "JSON".to_string(),
+            LogicalType::List => "LIST".to_string(),
+            LogicalType::Map => "MAP".to_string(),
+            LogicalType::String => "STRING".to_string(),
+            LogicalType::Time {
+                is_adjusted_to_u_t_c,
+                unit,
+            } => {
+                format!(
+                    "TIME({},{})",
+                    time_unit_to_string(unit),
+                    is_adjusted_to_u_t_c
+                )
+            }
+            LogicalType::Timestamp {
+                is_adjusted_to_u_t_c,
+                unit,
+            } => {
+                format!(
+                    "TIMESTAMP({},{})",
+                    time_unit_to_string(unit),
+                    is_adjusted_to_u_t_c
+                )
+            }
+            LogicalType::Uuid => "UUID".to_string(),
+            LogicalType::Unknown => "UNKNOWN".to_string(),
+        },
+        None => match converted_type {
+            ConvertedType::BSON => "BSON".to_string(),
+            ConvertedType::DATE => "DATE".to_string(),
+            ConvertedType::DECIMAL => format!("DECIMAL({},{})", precision, scale),
+            ConvertedType::ENUM => "ENUM".to_string(),
+            ConvertedType::INTERVAL => "INTERVAL".to_string(),
+            ConvertedType::INT_16 => "INT_16".to_string(),
+            ConvertedType::INT_32 => "INT_32".to_string(),
+            ConvertedType::INT_64 => "INT_64".to_string(),
+            ConvertedType::INT_8 => "INT_8".to_string(),
+            ConvertedType::JSON => "JSON".to_string(),
+            ConvertedType::LIST => "LIST".to_string(),
+            ConvertedType::MAP => "MAP".to_string(),
+            ConvertedType::MAP_KEY_VALUE => "MAP_KEY_VALUE".to_string(),
+            ConvertedType::NONE => "".to_string(),
+            ConvertedType::TIMESTAMP_MICROS => "TIMESTAMP_MICROS".to_string(),
+            ConvertedType::TIMESTAMP_MILLIS => "TIMESTAMP_MILLIS".to_string(),
+            ConvertedType::TIME_MICROS => "TIME_MICROS".to_string(),
+            ConvertedType::TIME_MILLIS => "TIME_MILLIS".to_string(),
+            ConvertedType::UINT_16 => "UINT_16".to_string(),
+            ConvertedType::UINT_32 => "UINT_32".to_string(),
+            ConvertedType::UINT_64 => "UINT_64".to_string(),
+            ConvertedType::UINT_8 => "UINT_8".to_string(),
+            ConvertedType::UTF8 => "UTF8".to_string(),
+        },
+    }
+}
+
+fn time_unit_to_string(unit: TimeUnit) -> String {
+    match unit {
+        TimeUnit::MILLIS(_) => "MILLISECONDS".to_string(),
+        TimeUnit::MICROS(_) => "MICROSECONDS".to_string(),
+        TimeUnit::NANOS(_) => "NANOSECONDS".to_string(),
+    }
+}
+
+fn row_groups_to_value(row_groups: &[RowGroupMetaData], span: Span) -> Value {
+    let mut vals = Vec::new();
+    for (_, row_group) in row_groups.iter().enumerate() {
+        let mut val = IndexMap::new();
+        val.insert(
+            "num_rows".to_string(),
+            Value::int(row_group.num_rows() as i64, span),
+        );
+        val.insert(
+            "total_byte_size".to_string(),
+            Value::int(row_group.total_byte_size() as i64, span),
+        );
+        vals.push(Value::from(Spanned { item: val, span }));
     }
     Value::List { vals, span }
 }


### PR DESCRIPTION
This PR adds the -m/--metadata flag to show the metadata (including schema) of the parquet file instead of the data. Definitely open to feedback around the approach, ux, etc.