### PR TITLE
Add "to parquet" command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,22 +6,22 @@ use nu_plugin::{
 };
 use nu_protocol::{Category, Example, LabeledError, Signature, Type, Value};
 
-pub struct FromParquetPlugin;
+pub struct ParquetPlugin;
 
-impl Plugin for FromParquetPlugin {
+impl Plugin for ParquetPlugin {
     fn version(&self) -> String {
         env!("CARGO_PKG_VERSION").into()
     }
 
     fn commands(&self) -> Vec<Box<dyn PluginCommand<Plugin = Self>>> {
-        vec![Box::new(FromParquet)]
+        vec![Box::new(FromParquet), Box::new(ToParquet)]
     }
 }
 
 struct FromParquet;
 
 impl SimplePluginCommand for FromParquet {
-    type Plugin = FromParquetPlugin;
+    type Plugin = ParquetPlugin;
 
     fn name(&self) -> &str {
         "from parquet"
@@ -65,7 +65,7 @@ impl SimplePluginCommand for FromParquet {
 
     fn run(
         &self,
-        _plugin: &FromParquetPlugin,
+        _plugin: &ParquetPlugin,
         _engine: &EngineInterface,
         call: &EvaluatedCall,
         input: &Value,
@@ -87,6 +87,64 @@ impl SimplePluginCommand for FromParquet {
     }
 }
 
+struct ToParquet;
+
+impl SimplePluginCommand for ToParquet {
+    type Plugin = ParquetPlugin;
+
+    fn name(&self) -> &str {
+        "to parquet".into()
+    }
+
+    fn usage(&self) -> &str {
+        "Convert from table to .parquet binary"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(PluginCommand::name(self))
+            .allow_variants_without_examples(true)
+            .input_output_types(vec![(Type::Any, Type::String)])
+            .category(Category::Experimental)
+            .filter()
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Convert from table into parquet binary".into(),
+                example: "[{a:1}, {a: 2}] | to parquet".into(),
+                result: None,
+            },
+            Example {
+                description: "Store as parquet file".into(),
+                example: "[{a:1}, {a: 2}] | save file.parquet".into(),
+                result: None,
+            }
+        ]
+    }
+
+    fn run(
+            &self,
+            plugin: &Self::Plugin,
+            engine: &EngineInterface,
+            call: &EvaluatedCall,
+            input: &Value,
+        ) -> Result<Value, LabeledError> {
+            let span = input.span();
+            match input {
+                Value::List { vals, internal_span, .. } => crate::from_parquet::to_parquet_bytes(vals, span),
+                v => {
+                    return Err(LabeledError::new(format!(
+                        "requires table input, got {}",
+                        v.get_type()
+                    ))
+                    .with_label("Expected table from pipeline", call.head))
+                }
+            }
+    }
+}
+
+
 fn main() {
-    serve_plugin(&mut FromParquetPlugin, MsgPackSerializer {});
+    serve_plugin(&mut ParquetPlugin, MsgPackSerializer {});
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,7 +103,7 @@ impl SimplePluginCommand for ToParquet {
     fn signature(&self) -> Signature {
         Signature::build(PluginCommand::name(self))
             .allow_variants_without_examples(true)
-            .input_output_types(vec![(Type::Any, Type::String)])
+            .input_output_types(vec![(Type::Any, Type::Binary)])
             .category(Category::Experimental)
             .filter()
     }


### PR DESCRIPTION
Add ability to also store parquet files. Example:
```shell
$ [{a:1, b:3}, {a: 2, b:4}] | save tmp.parquet
$ open tmp.parquet
╭───┬───┬───╮
│ # │ a │ b │
├───┼───┼───┤
│ 0 │ 1 │ 3 │
│ 1 │ 2 │ 4 │
╰───┴───┴───╯
```

A few to-dos:
 - Rename crate ? Or even repo ?
 - Supported types : int, float, string, filesize. Not supported: date
 - Filesize are stored as int, and therefore loose their original type when read. `to csv` stores them as `string`, maybe it's a better idea ?